### PR TITLE
Fix OCEL.get_value

### DIFF
--- a/ocpa/objects/log/ocel.py
+++ b/ocpa/objects/log/ocel.py
@@ -208,7 +208,7 @@ class OCEL:
         This function is the most efficient attribute value retrieval.
 
         :param o_id: object id of the targeted object
-        :type e_id: str
+        :type o_id: str
         :param attribute: attribute name of the targeted attribute, should be a column of the passed table
         :type attribute: string
         :return: any value

--- a/ocpa/objects/log/variants/table.py
+++ b/ocpa/objects/log/variants/table.py
@@ -34,7 +34,7 @@ class Table:
         self._numpy_log = self._log.to_numpy()
         self._column_mapping = {k: v for v, k in enumerate(
             list(self._log.columns.values))}
-        self._mapping = {c: dict(
+        self._mapping = {int(c): dict(
             zip(self._log["event_id"], self._log[c])) for c in self._log.columns.values}
         if self._object_attributes:
             self._object_attributes = {c: dict(


### PR DESCRIPTION
In the documentation of `get_value`, event id is specified to be an int, which seems to be consistent with the output of the variant calculation. However, when trying to access an attribute of an event, the event id has to be casted into a string first at the current version.

This is fixed by casting the keys of `_mapping` in the Table class to integers.