### PR TITLE
Do not return None for service time, instead use 0

### DIFF
--- a/ocpa/algo/predictive_monitoring/event_based_features/extraction_functions.py
+++ b/ocpa/algo/predictive_monitoring/event_based_features/extraction_functions.py
@@ -281,18 +281,9 @@ def lagging_time(node, ocel, params):
 
     return sum(res) / len(res)
 
-def event_duration(node, ocel, params):
-    start_column = params[0]
-    return (ocel.get_value(node.event_id, "event_timestamp") - ocel.get_value(node.event_id,
-                                                                              start_column)).total_seconds()
-
 def service_time(node, ocel, params):
     start_column = params[0]
-    activity = params[1]
-    if ocel.get_value(node.event_id,"event_activity") == activity:
-        return (ocel.get_value(node.event_id,"event_timestamp") - ocel.get_value(node.event_id,start_column)).total_seconds()
-    else:
-        return 0
+    return (ocel.get_value(node.event_id,"event_timestamp") - ocel.get_value(node.event_id,start_column)).total_seconds()
 
 
 #objects

--- a/ocpa/algo/predictive_monitoring/event_based_features/extraction_functions.py
+++ b/ocpa/algo/predictive_monitoring/event_based_features/extraction_functions.py
@@ -292,7 +292,7 @@ def service_time(node, ocel, params):
     if ocel.get_value(node.event_id,"event_activity") == activity:
         return (ocel.get_value(node.event_id,"event_timestamp") - ocel.get_value(node.event_id,start_column)).total_seconds()
     else:
-        return None
+        return 0
 
 
 #objects

--- a/ocpa/algo/predictive_monitoring/factory.py
+++ b/ocpa/algo/predictive_monitoring/factory.py
@@ -29,7 +29,6 @@ EVENT_OBJECTS = "event_objects"
 EVENT_EXECUTION_DURATION = "event_execution_time"
 EVENT_ELAPSED_TIME = "event_elapsed_time"
 EVENT_REMAINING_TIME = "event_remaining_time"
-EVENT_DURATION = "event_duration"
 EVENT_FLOW_TIME = "event_flow_time"
 EVENT_SYNCHRONIZATION_TIME = "event_synchronization_time"
 EVENT_SOJOURN_TIME = "event_sojourn_time"
@@ -72,7 +71,6 @@ VERSIONS = {
                   EVENT_EXECUTION_DURATION: event_features.execution_duration,
                   EVENT_ELAPSED_TIME: event_features.elapsed_time,
                   EVENT_REMAINING_TIME: event_features.remaining_time,
-                  EVENT_DURATION: event_features.event_duration,
                   EVENT_LAGGING_TIME: event_features.lagging_time,
                   EVENT_POOLING_TIME: event_features.pooling_time,
                   EVENT_WAITING_TIME: event_features.waiting_time,


### PR DESCRIPTION
Some prediction models have problems with nan values. Therefore, fill the nan value directly in the feature extraction with the value 0.