### PR TITLE
Better feature extraction parallelization #7

### DIFF
--- a/ocpa/algo/predictive_monitoring/factory.py
+++ b/ocpa/algo/predictive_monitoring/factory.py
@@ -1,4 +1,7 @@
 import time
+from multiprocessing import Pool
+from random import shuffle
+
 import tqdm
 from multiprocessing.dummy import Pool as ThreadPool
 import ocpa.algo.predictive_monitoring.event_based_features.extraction_functions as event_features
@@ -164,11 +167,19 @@ def apply(ocel, event_based_features=[], execution_based_features=[], event_attr
     ocel.log.create_efficiency_objects()
     feature_storage = Feature_Storage(
         event_features=event_based_features, execution_features=execution_based_features, ocel=ocel)
-    pool = ThreadPool(workers)
-    parameter_space = [(c_id,ocel,event_based_features, execution_based_features, event_attributes, event_object_attributes, execution_object_attributes, multi_output_event_features ) for c_id in range(0,len(ocel.process_executions))]
+
     print("Applying feature extraction to process executions")
-    results = list(tqdm.tqdm(pool.imap(_apply_to_process_execution, parameter_space), total=len(parameter_space)))
-    for f_g in results:
-        feature_storage.add_feature_graph(f_g)
+    parameter_space = [(c_id, ocel, event_based_features, execution_based_features, event_attributes,
+                        event_object_attributes, execution_object_attributes, multi_output_event_features) for c_id in
+                       range(0, len(ocel.process_executions))]
+    # Shuffle parameter space to avoid that one process gets only very long-running cases
+    shuffle(parameter_space)
+    chunksize, extra = divmod(len(parameter_space), workers * 16)
+    if extra:
+        chunksize += 1
+    with Pool(workers) as pool:
+        for f_g in tqdm.tqdm(pool.imap_unordered(_apply_to_process_execution, parameter_space, chunksize=chunksize),
+                             total=len(parameter_space)):
+            feature_storage.add_feature_graph(f_g)
     del ocel.log.log["event_objects"]
     return feature_storage

--- a/ocpa/algo/predictive_monitoring/obj.py
+++ b/ocpa/algo/predictive_monitoring/obj.py
@@ -65,9 +65,9 @@ class Feature_Storage:
             target = property(_get_target)
             objects = property(_get_objects)
 
-        def __init__(self, case_id, graph, ocel):
-            self._case_id = case_id
-            self._nodes = [Feature_Storage.Feature_Graph.Node(e_id, ocel.get_value(e_id, "event_objects"),case_id) for e_id in
+        def __init__(self, pexec_id, graph, ocel):
+            self._pexec_id = pexec_id
+            self._nodes = [Feature_Storage.Feature_Graph.Node(e_id, ocel.get_value(e_id, "event_objects"),pexec_id) for e_id in
                            graph.nodes]
             #self._nodes = [Feature_Storage.Feature_Graph.Node(e_id, ocel.log.loc[e_id]["event_objects"]) for e_id in graph.nodes]
             self._node_mapping = {node.event_id: node for node in self._nodes}
@@ -82,6 +82,9 @@ class Feature_Storage:
 
         def _get_nodes(self):
             return self._nodes
+        
+        def _get_pexec_id(self):
+            return self._pexec_id
 
         def _get_edges(self):
             return self._edges
@@ -106,6 +109,7 @@ class Feature_Storage:
             self._attributes[key] = value
 
         attributes = property(_get_attributes)
+        pexec_id = property(_get_pexec_id)
         nodes = property(_get_nodes)
         edges = property(_get_edges)
         objects = property(_get_objects)


### PR DESCRIPTION
This version uses a process pool. Before starting the pool, it shuffles the process executions (they seem to be ordered by length in descending order) so that the work is spread equally among workers. The Pool uses a reasonable chunk size and adds results unordered on the fly without combining the feature graphs into a list first.