### PR TITLE
Match to process execution id when indexing the feature graphs

### DIFF
--- a/ocpa/algo/predictive_monitoring/obj.py
+++ b/ocpa/algo/predictive_monitoring/obj.py
@@ -204,8 +204,14 @@ class Feature_Storage:
         # print(split_index)
         self._training_indices = graphs_indices[:split_index]
         self._test_indices = graphs_indices[split_index:]
-        train_graphs, test_graphs = [self.feature_graphs[i] for i in self._training_indices], [
-            self.feature_graphs[i] for i in self._test_indices]
+        train_graphs, test_graphs = [], []
+        for g in self.feature_graphs:
+            if g.pexec_id in self._training_indices:
+                train_graphs.append(g)
+            elif g.pexec_id in self._test_indices:
+                test_graphs.append(g)
+            else:
+                raise Exception("Graph not in training or test set")
         # Normalize
         features = self.event_features
         train_table = self._event_id_table(train_graphs)
@@ -221,11 +227,12 @@ class Feature_Storage:
         train_mapper = self._create_mapper(train_table)
         test_mapper = self._create_mapper(test_table)
         # change original values!
-        for g in [self.feature_graphs[i] for i in self.training_indices]:
+        for g in self.feature_graphs:
             for node in g.nodes:
                 for att in node.attributes.keys():
-                    node.attributes[att] = train_mapper[node.event_id][att]
-        for g in [self.feature_graphs[i] for i in self.test_indices]:
-            for node in g.nodes:
-                for att in node.attributes.keys():
-                    node.attributes[att] = test_mapper[node.event_id][att]
+                    if g.pexec_id in self._training_indices:
+                        node.attributes[att] = train_mapper[node.event_id][att]
+                    elif g.pexec_id in self._test_indices:
+                        node.attributes[att] = test_mapper[node.event_id][att]
+                    else:
+                        raise Exception("Graph not in training or test set")

--- a/ocpa/algo/predictive_monitoring/obj.py
+++ b/ocpa/algo/predictive_monitoring/obj.py
@@ -228,11 +228,13 @@ class Feature_Storage:
         test_mapper = self._create_mapper(test_table)
         # change original values!
         for g in self.feature_graphs:
-            for node in g.nodes:
-                for att in node.attributes.keys():
-                    if g.pexec_id in self._training_indices:
+            if g.pexec_id in self._training_indices:
+                for node in g.nodes:
+                    for att in node.attributes.keys():
                         node.attributes[att] = train_mapper[node.event_id][att]
-                    elif g.pexec_id in self._test_indices:
+            elif g.pexec_id in self._test_indices:
+                for node in g.nodes:
+                    for att in node.attributes.keys():
                         node.attributes[att] = test_mapper[node.event_id][att]
-                    else:
-                        raise Exception("Graph not in training or test set")
+            else:
+                raise Exception("Graph not in training or test set")

--- a/ocpa/algo/predictive_monitoring/sequential.py
+++ b/ocpa/algo/predictive_monitoring/sequential.py
@@ -12,19 +12,18 @@ def construct_sequence(feature_storage, index_list = "all"):
     :rtype: list(list(dict))
 
     '''
-    if index_list == "all":
-        index_list = list(range(0, len(feature_storage.feature_graphs)))
     sequences = []
-    for g in [feature_storage.feature_graphs[i] for i in index_list]:
-        sequence = []
-        #sort nodes on event time (through the event id)
-        event_ids = [n.event_id for n in g.nodes]
-        event_ids.sort()
-        for e_id in event_ids:
-            for node in g.nodes:
-                if e_id == node.event_id:
-                    sequence.append(node.attributes)
-        sequences.append(sequence)
+    for g in feature_storage.feature_graphs:
+        if index_list == "all" or g.pexec_id in index_list:
+            sequence = []
+            #sort nodes on event time (through the event id)
+            event_ids = [n.event_id for n in g.nodes]
+            event_ids.sort()
+            for e_id in event_ids:
+                for node in g.nodes:
+                    if e_id == node.event_id:
+                        sequence.append(node.attributes)
+            sequences.append(sequence)
     return sequences
 
 def construct_k_dataset(sequences, k, features, target):

--- a/ocpa/algo/predictive_monitoring/tabular.py
+++ b/ocpa/algo/predictive_monitoring/tabular.py
@@ -13,11 +13,10 @@ def construct_table(feature_storage, index_list = "all"):
     :return: List of sequential encodings: Each sequential encoding is a sequence of feature dicts.
     :rtype: list(list(dict))
     '''
-    if index_list == "all":
-        index_list = list(range(0,len(feature_storage.feature_graphs)))
     dict_list = []
-    for g in [feature_storage.feature_graphs[i] for i in index_list]:
-        for node in g.nodes:
-            dict_list.append(node.attributes)
+    for g in feature_storage.feature_graphs:
+        if index_list == "all" or g.pexec_id in index_list:
+            for node in g.nodes:
+                dict_list.append(node.attributes)
     df = pd.DataFrame(dict_list)
     return df


### PR DESCRIPTION
This ensures that the e.g. training indices refer to the same process executions when comparing different feature storages (e.g. when extracting different features in different runs)