### PR TITLE
Removed use of `eval` function + fixed IndexError

### DIFF
--- a/ocpa/algo/discovery/ocpn/versions/new_inductive.py
+++ b/ocpa/algo/discovery/ocpn/versions/new_inductive.py
@@ -5,7 +5,8 @@ from pm4py.objects.petri_net.utils.petri_utils import remove_place, remove_trans
 from pm4py.objects.petri_net.obj import PetriNet
 from ocpa.algo.util.util import project_log, project_log_with_object_count
 from ocpa.objects.oc_petri_net.obj import ObjectCentricPetriNet
-from ocpa.objects.log.importer.csv.util import succint_mdl_to_exploded_mdl, clean_frequency, clean_arc_frequency
+from ocpa.objects.log.importer.csv.util import succint_mdl_to_exploded_mdl, clean_frequency, clean_arc_frequency, \
+    clean_normalized_frequency
 import pandas as pd
 import time
 import networkx as nx
@@ -54,9 +55,11 @@ def discover_nets(df, discovery_algorithm=discover_inductive, parameters=None):
     if len(df) == 0:
         df = pd.DataFrame({"event_id": [], "event_activity": []})
 
+    activity_threshold: float = parameters["activity_threshold"] if "activity_threshold" in parameters else 0.0
     min_node_freq = parameters["min_node_freq"] if "min_node_freq" in parameters else 0
     min_edge_freq = parameters["min_edge_freq"] if "min_edge_freq" in parameters else 0
 
+    df = clean_normalized_frequency(df, activity_threshold)
     df = clean_frequency(df, min_node_freq)
     df = clean_arc_frequency(df, min_edge_freq)
 

--- a/ocpa/objects/log/importer/csv/util.py
+++ b/ocpa/objects/log/importer/csv/util.py
@@ -37,10 +37,10 @@ def succint_stream_to_exploded_stream(stream):
         basic_event = {k: ev[k] for k in event_keys}
 
         for k in object_keys:
-            if type(ev[k]) is str:
+            if type(ev[k]) is str and len(ev[k]) > 0:
                 if ev[k][0] == "{":
+                    # TODO: Remove eval - security risk
                     ev[k] = eval(ev[k])
-                    #ev[k] = ev[k][1:-1].split(",")
             values = ev[k]
             if values is not None:
                 # if values is not None and len(values) > 0:

--- a/ocpa/objects/log/importer/csv/util.py
+++ b/ocpa/objects/log/importer/csv/util.py
@@ -110,6 +110,37 @@ def succint_mdl_to_exploded_mdl(df, parameters=None):
     return df
 
 
+def clean_normalized_frequency(df, threshold=0):
+    """
+    Filter out activities based on threshold.
+    0.0 = keep everything
+    1.0 = keep only important activities
+    """
+    if threshold == 0:
+        return df
+    try:
+        if df.type == "succint":
+            df = succint_mdl_to_exploded_mdl(df)
+    except:
+        pass
+
+    # Calculate activity frequencies
+    activity_counts = df.groupby("event_id").first()["event_activity"].value_counts(normalize=True)
+
+    # Get min and max values of the normalized activity counts
+    min_freq = activity_counts.min()
+    max_freq = activity_counts.max()
+
+    # Map threshold to the range between min and max
+    mapped_threshold = min_freq + (max_freq - min_freq) * threshold
+
+    # Determine important activities based on the mapped threshold
+    important_activities = activity_counts[activity_counts >= mapped_threshold].index.tolist()
+
+    # Filter dataframe to keep only important activities
+    return df[df["event_activity"].isin(important_activities)]
+
+
 def clean_frequency(df, min_acti_freq=0):
     try:
         if df.type == "succint":

--- a/ocpa/objects/log/importer/csv/util.py
+++ b/ocpa/objects/log/importer/csv/util.py
@@ -93,8 +93,7 @@ def clean_frequency(df, min_acti_freq=0):
             df = succint_mdl_to_exploded_mdl(df)
     except:
         pass
-    activ = dict(df.groupby("event_id").first()[
-                     "event_activity"].value_counts())
+    activ = dict(df.groupby("event_id").first()["event_activity"].value_counts())
     activ = [x for x, y in activ.items() if y >= min_acti_freq]
     return df[df["event_activity"].isin(activ)]
 
@@ -136,11 +135,9 @@ def filter_paths(df, paths, parameters=None):
     positive = parameters["positive"] if "positive" in parameters else True
     filt_df = df[[case_id_glue, attribute_key, "event_id"]]
     filt_dif_shifted = filt_df.shift(-1)
-    filt_dif_shifted.columns = [
-        str(col) + '_2' for col in filt_dif_shifted.columns]
+    filt_dif_shifted.columns = [str(col) + '_2' for col in filt_dif_shifted.columns]
     stacked_df = pd.concat([filt_df, filt_dif_shifted], axis=1)
-    stacked_df["@@path"] = stacked_df[attribute_key] + \
-                           "," + stacked_df[attribute_key + "_2"]
+    stacked_df["@@path"] = stacked_df[attribute_key] + "," + stacked_df[attribute_key + "_2"]
     stacked_df = stacked_df[stacked_df["@@path"].isin(paths)]
     i1 = df.set_index("event_id").index
     i2 = stacked_df.set_index("event_id").index

--- a/ocpa/visualization/oc_petri_net/factory.py
+++ b/ocpa/visualization/oc_petri_net/factory.py
@@ -2,7 +2,6 @@ from ocpa.visualization.oc_petri_net.versions import control_flow, annotated_wit
 from pm4py.visualization.common import gview
 from pm4py.visualization.common import save as gsave
 
-
 CONTROL_FLOW = "control_flow"
 NEW_CONTROL_FLOW = "new_control_flow"
 ANNOTATED_WITH_OPERA = "annotated_with_opera"
@@ -12,7 +11,8 @@ VERSIONS = {
     CONTROL_FLOW: control_flow.apply,
     NEW_CONTROL_FLOW: new_control_flow.apply,
     ANNOTATED_WITH_OPERA: annotated_with_opera.apply,
-    OCPI: ocpi.apply}
+    OCPI: ocpi.apply
+}
 
 
 def apply(obj, variant=NEW_CONTROL_FLOW, **kwargs):

--- a/ocpa/visualization/oc_petri_net/versions/new_control_flow.py
+++ b/ocpa/visualization/oc_petri_net/versions/new_control_flow.py
@@ -8,10 +8,10 @@ COLORS = [
     '#ff3399',
     '#f58b55',
     '#f25e65',
-    '#261926',
+    '#261926',  # too dark
     '#ddb14d',
     '#5387d5',
-    '#1c3474',
+    '#1c3474',  # too dark
     '#a37554',
     '#8bc34a',
     '#cddc39',
@@ -19,12 +19,45 @@ COLORS = [
     '#ffc107',
     '#ff9800',
     '#ff5722',
-    '#795548',
-    '#9e9e9e',
-    '#607d8b',
+    '#795548',  # borderline
+    '#9e9e9e',  # gray
+    '#607d8b',  # borderline
     '#9affff',
     '#000000'
 ]
+
+
+def is_color_too_dark(hex_color: str, luminance_threshold: float = 0.2) -> bool:
+    """
+    Determines if a hex color is too dark based on its relative luminance.
+
+    Args:
+        hex_color (str): The hex color code string (e.g., "#1c3474").
+        luminance_threshold (float): The luminance threshold below which the color is considered too dark.
+
+    Returns:
+        bool: True if the color is too dark, False otherwise.
+    """
+    # Remove the hash (#) if present
+    hex_color = hex_color.lstrip('#')
+
+    # Convert the hex color to RGB components (0-255 range)
+    r, g, b = int(hex_color[0:2], 16), int(hex_color[2:4], 16), int(hex_color[4:6], 16)
+
+    # Normalize RGB values to 0-1 range
+    r /= 255.0
+    g /= 255.0
+    b /= 255.0
+
+    # Calculate the relative luminance based on the sRGB formula
+    def adjust(color_component):
+        return color_component / 12.92 if color_component <= 0.03928 else ((color_component + 0.055) / 1.055) ** 2.4
+
+    r, g, b = adjust(r), adjust(g), adjust(b)
+    luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b
+
+    # Return True if the luminance is below the threshold
+    return luminance < luminance_threshold
 
 
 def apply(ocpn: ObjectCentricPetriNet, parameters=None):
@@ -59,12 +92,18 @@ def apply(ocpn: ObjectCentricPetriNet, parameters=None):
         pl_label = pl.object_type
         pl_count += 1
         color = color_mapping[pl.object_type]
+        label_color = "white" if is_color_too_dark(color) else "black"
         if pl.initial == True or pl.final == True:
-            g.node(this_uuid, pl_label, shape="circle", style="filled", fillcolor=color, color=color,
-                   fontsize="13.0", labelfontsize="13.0", width="0.5", height="0.5")  # Smaller size
+            g.node(
+                this_uuid, pl_label, shape="circle", style="filled", fillcolor=color, color=color,
+                fontcolor=label_color, fontsize="13.0", labelfontsize="13.0", width="0.5",
+                height="0.5"
+            )
         else:
-            g.node(this_uuid, "", shape="circle", color=color,
-                   fontsize="13.0", labelfontsize="13.0", width="0.5", height="0.5")  # Smaller size
+            g.node(
+                this_uuid, "", shape="circle", color=color,
+                fontsize="13.0", labelfontsize="13.0", width="0.5", height="0.5"
+            )
         all_objs[pl] = this_uuid
 
     for tr in ocpn.transitions:

--- a/ocpa/visualization/oc_petri_net/versions/new_control_flow.py
+++ b/ocpa/visualization/oc_petri_net/versions/new_control_flow.py
@@ -3,43 +3,44 @@ import tempfile
 from graphviz import Digraph
 from ocpa.objects.oc_petri_net.obj import ObjectCentricPetriNet
 
-COLORS = ['#7f66ff',
-          '#ff3399',
-          '#f58b55',
-          '#f25e65',
-          '#261926',
-          '#ddb14d',
-          '#5387d5',
-          '#1c3474',
-          '#a37554',
-          '#8bc34a',
-          '#cddc39',
-          '#ffeb3b',
-          '#ffc107',
-          '#ff9800',
-          '#ff5722',
-          '#795548',
-          '#9e9e9e',
-          '#607d8b',
-          '#9affff',
-          '#000000']
+COLORS = [
+    '#7f66ff',
+    '#ff3399',
+    '#f58b55',
+    '#f25e65',
+    '#261926',
+    '#ddb14d',
+    '#5387d5',
+    '#1c3474',
+    '#a37554',
+    '#8bc34a',
+    '#cddc39',
+    '#ffeb3b',
+    '#ffc107',
+    '#ff9800',
+    '#ff5722',
+    '#795548',
+    '#9e9e9e',
+    '#607d8b',
+    '#9affff',
+    '#000000'
+]
 
 
 def apply(ocpn: ObjectCentricPetriNet, parameters=None):
     if parameters is None:
         parameters = {}
 
-    image_format = "png"
-    if "format" in parameters:
-        image_format = parameters["format"]
+    image_format = parameters.get('format') or "png"
+    background_color = parameters.get('bgcolor') or "transparent"
 
     filename = tempfile.NamedTemporaryFile(suffix='.gv').name
 
-    g = Digraph("", filename=filename, engine='dot',
-                graph_attr={'bgcolor': 'transparent'})
-    if "ratio" in parameters:
-        ratio = parameters["ratio"]
+    g = Digraph("", filename=filename, engine='dot', graph_attr={'bgcolor': background_color})
+
+    if ratio := parameters.get('ratio'):
         g.attr(ratio=ratio)
+
     all_objs = {}
     trans_names = {}
 
@@ -61,10 +62,10 @@ def apply(ocpn: ObjectCentricPetriNet, parameters=None):
         color = color_mapping[pl.object_type]
         if pl.initial == True or pl.final == True:
             g.node(this_uuid, pl_label, shape="circle", style="filled", fillcolor=color, color=color,
-                fontsize="13.0", labelfontsize="13.0", width="0.5", height="0.5")  # Smaller size
+                   fontsize="13.0", labelfontsize="13.0", width="0.5", height="0.5")  # Smaller size
         else:
             g.node(this_uuid, "", shape="circle", color=color,
-                fontsize="13.0", labelfontsize="13.0", width="0.5", height="0.5")  # Smaller size
+                   fontsize="13.0", labelfontsize="13.0", width="0.5", height="0.5")  # Smaller size
         all_objs[pl] = this_uuid
 
     for tr in ocpn.transitions:
@@ -72,16 +73,15 @@ def apply(ocpn: ObjectCentricPetriNet, parameters=None):
         tr_count += 1
         if tr.silent == True:
             g.node(this_uuid, "", fontcolor="#FFFFFF", shape="box",
-                fillcolor="#000000", style="filled", width="0.1", height="0.1")  # Even smaller size
+                   fillcolor="#000000", style="filled", width="0.1", height="0.1")  # Even smaller size
             all_objs[tr] = this_uuid  # this_uuid
         elif tr.label not in trans_names:
             g.node(this_uuid, tr.label, shape="box", fontsize="13.0",
-                labelfontsize="13.0", width="0.7", height="0.7")  # Larger size
+                   labelfontsize="13.0", width="0.7", height="0.7")  # Larger size
             trans_names[tr.label] = tr.label  # this_uuid
             all_objs[tr] = this_uuid
         else:
             all_objs[tr] = this_uuid
-
 
     for arc in ocpn.arcs:
         this_uuid = str(uuid.uuid4())

--- a/ocpa/visualization/oc_petri_net/versions/new_control_flow.py
+++ b/ocpa/visualization/oc_petri_net/versions/new_control_flow.py
@@ -46,7 +46,6 @@ def apply(ocpn: ObjectCentricPetriNet, parameters=None):
 
     pl_count = 1
     tr_count = 1
-    arc_count = 1
 
     # color = COLORS[index % len(COLORS)]
     color = "#05B202"


### PR DESCRIPTION
The contribution of this pull request is twofold:
1. Fix a bug that I encountered where some objects would be evaluated to an empty string. This empty string was accessed without checking whether it was empty or not resulting in an index out of bounds exception.
2. Removal of the usage of the python built-in function `eval` which is a security hazard. Consider the following string: `'{ exec("import os"), exec("print(os.getlogin())")}'`. This string passes the condition `if ev[k][0] == "{":`. It is then passed to the eval function which allows the execution of code. This simple example can easily be made into an exploit, allowing unsensitized input to result in execution of unwanted code.

Minor changes:
- Minor code improvements
- Added the ability to set a background color when using `oc_petri_net`.