### PR TITLE
fix: fix issue causing alignments to be log-only

### DIFF
--- a/ocpa/algo/conformance/alignments/algorithm.py
+++ b/ocpa/algo/conformance/alignments/algorithm.py
@@ -314,8 +314,8 @@ def create_all_transitions(ocpn: ObjectCentricPetriNet,
                 signature_in[in_arc.source.object_type] += 1
 
         # add signature to transition
-        model_move = UndefinedModelMove(model_move=transition.name, objects=None, silent=transition.silent)
-        set_properties_of_transition(new_transition, TransitionSignature(transition.name, signature_in,
+        model_move = UndefinedModelMove(model_move=transition.label, objects=None, silent=transition.silent)
+        set_properties_of_transition(new_transition, TransitionSignature(transition.label, signature_in,
                                                                          signature_in, model_move))
         # trans_prop = get_properties_of_transition(new_transition)
         # #print(f"Transitions property: {get_properties_of_transition(new_transition)}")
@@ -381,8 +381,8 @@ def preprocessing_dejure_net(ocel: OCEL, indirect_id, ocpn):
                     card_signature_in.setdefault(in_arc.source.object_type, 0)
                     card_signature_in[in_arc.source.object_type] += 1
 
-            model_move = UndefinedModelMove(model_move=transition.name, objects=None, silent=transition.silent)
-            set_properties_of_transition(transition, TransitionSignature(transition.name, card_signature_in,
+            model_move = UndefinedModelMove(model_move=transition.label, objects=None, silent=transition.silent)
+            set_properties_of_transition(transition, TransitionSignature(transition.label, card_signature_in,
                                                                              card_signature_in, model_move))
             continue
 

--- a/ocpa/objects/oc_petri_net/obj.py
+++ b/ocpa/objects/oc_petri_net/obj.py
@@ -80,15 +80,27 @@ class ObjectCentricPetriNet(object):
         def __deepcopy__(self, memodict={}):
             if id(self) in memodict:
                 return memodict[id(self)]
-            new_place = ObjectCentricPetriNet.Place(
-                self.name, self.object_type)
+            
+            name = getattr(self, "name", None)
+            object_type = getattr(self, "object_type", None)
+            initial = getattr(self, "initial", False)
+            final = getattr(self, "final", False)
+            
+            # copy initial and final flags as well
+            new_place = self.__class__(name, object_type, initial=initial, final=final)
+            # copy properties if they exist
+            if hasattr(self, 'properties'):
+                try:
+                    setattr(new_place, 'properties', deepcopy(getattr(self, 'properties'), memo=memodict))
+                except Exception:
+                    setattr(new_place, 'properties', getattr(self, 'properties'))
             memodict[id(self)] = new_place
-            for arc in self.in_arcs:
-                new_arc = deepcopy(arc, memo=memodict)
-                new_place.in_arcs.add(new_arc)
-            for arc in self.out_arcs:
-                new_arc = deepcopy(arc, memo=memodict)
-                new_place.out_arcs.add(new_arc)
+
+            # Init in_arcs and out_arcs if they do not exist
+            # No longer attach arcs during deepcopy of place, 
+            # do it when deepcopying the arcs instead to remove duplicated arcs
+            if not hasattr(new_place, "in_arcs"):  new_place.in_arcs  = set()
+            if not hasattr(new_place, "out_arcs"): new_place.out_arcs = set()
             return new_place
 
         object_type = property(__get_object_type)
@@ -186,15 +198,20 @@ class ObjectCentricPetriNet(object):
         def __deepcopy__(self, memodict={}):
             if id(self) in memodict:
                 return memodict[id(self)]
-            new_trans = ObjectCentricPetriNet.Transition(
-                self.name, self.label, properties=self.properties)
+            
+            name  = getattr(self, "name", None)
+            label = getattr(self, "label", None)
+            properties = getattr(self, "properties", None)
+            silent = getattr(self, "silent", False)
+
+            # copy silent flag as well
+            new_trans = self.__class__(name, label, properties=properties, silent=silent)
             memodict[id(self)] = new_trans
-            for arc in self.in_arcs:
-                new_arc = deepcopy(arc, memo=memodict)
-                new_trans.in_arcs.add(new_arc)
-            for arc in self.out_arcs:
-                new_arc = deepcopy(arc, memo=memodict)
-                new_trans.out_arcs.add(new_arc)
+
+            # No longer attach arcs during deepcopy of transition, 
+            # do it when deepcopying the arcs instead to remove duplicated arcs
+            if not hasattr(new_trans, "in_arcs"):  new_trans.in_arcs  = set()
+            if not hasattr(new_trans, "out_arcs"): new_trans.out_arcs = set()
             return new_trans
 
         def to_dict(self):
@@ -272,15 +289,22 @@ class ObjectCentricPetriNet(object):
         def __deepcopy__(self, memodict={}):
             if id(self) in memodict:
                 return memodict[id(self)]
-            new_source = memodict[id(self.source)] if id(self.source) in memodict else deepcopy(self.source,
-                                                                                                memo=memodict)
-            new_target = memodict[id(self.target)] if id(self.target) in memodict else deepcopy(self.target,
-                                                                                                memo=memodict)
-            memodict[id(self.source)] = new_source
-            memodict[id(self.target)] = new_target
-            new_arc = ObjectCentricPetriNet.Arc(
-                new_source, new_target, weight=self.weight, properties=self.properties)
+
+            new_source = deepcopy(getattr(self, "source", None), memo=memodict)
+            new_target = deepcopy(getattr(self, "target", None), memo=memodict)
+
+            weight   = getattr(self, "weight", 1)
+            variable = getattr(self, "variable", False)
+            properties = getattr(self, "properties", None)
+
+            new_arc = self.__class__(new_source, new_target, weight=weight, variable=variable, properties=properties)
             memodict[id(self)] = new_arc
+
+            # Attach the new arc to the new source and target
+            if hasattr(new_source, "out_arcs"):
+                new_source.out_arcs.add(new_arc)
+            if hasattr(new_target, "in_arcs"):
+                new_target.in_arcs.add(new_arc)
             return new_arc
         
         def to_dict(self):


### PR DESCRIPTION
## Overview

- Currently the alignment calculation always results all activities as Log move.
- Debugged alignment calculation implementation to search for the reasons for no Sync or Model move.
- Found two reasons for the mis-calculation, and hotfixed them.


## Current Situation

- Tried for multiple log files with corresponding different ocel instance, the result are always Log move-only.
- Below is the example result with the log [`paper_example.jsonocel`](https://github.com/LukasLiss/object-centric-alignments/blob/main/sample-logs/jsonocel/paper-example.jsonocel) (OCEL 1.0) provided from [original "Object-Centric Alignments" papaer implementation](https://github.com/LukasLiss/object-centric-alignments).

**Desired Alignment output**
<img width="520" height="416" alt="desired" src="https://github.com/user-attachments/assets/42fc62e8-eff0-4ae9-ba05-a4e8595bd83a" />

**Actual output**
<img width="515" height="411" alt="actual" src="https://github.com/user-attachments/assets/bc4ecdec-f0b2-4547-8c68-e665fc80cd38" />

Every transition has been classified as log move.



## Reasons Found

1. No initial and final places are set for `external_ocpn`.

2. The `name` **(uuid)** of activities in dejure net (from OCPN) is compared to the `name` **(activity label)** of activities in process execution net (from OCEL), which occurs in-consistency.


## Change Log

### 1. Update `__deepcopy__` method for `Place`, `Transition`, `Arc` inside of [`ObjectCentricPetriNet`](https://github.com/ocpm/ocpa/blob/main/ocpa/objects/oc_petri_net/obj.py)

#### `Place.__deepcopy__`

copy and set `initial` and `final` attribute for new place

**Before**

```python
new_place = ObjectCentricPetriNet.Place(self.name, self.object_type)
```

**After**

```python
name = getattr(self, "name", None)
object_type = getattr(self, "object_type", None)
initial = getattr(self, "initial", False)
final = getattr(self, "final", False)

new_place = self.__class__(name, object_type, initial=initial, final=final)
```

#### `Transition.__deepcopy__`

copy and set `silent` flag attribute for new transition

**Before**

```python
new_trans = ObjectCentricPetriNet.Transition(self.name, self.label, properties=self.properties)
```

**After**

```python
new_trans = self.__class__(name, label, properties=properties, silent=silent)
```

#### `Arc.__deepcopy__`

Add current arc to source and target object (Place or Transition)

**After**

```python
if hasattr(new_source, "out_arcs"):
    new_source.out_arcs.add(new_arc)
if hasattr(new_target, "in_arcs"):
    new_target.in_arcs.add(new_arc)
```

### 2. Let `TransitionSignature` gets `transition.label` as a first argument instead of `transition.name`

**Before**

```python
# add signature to transition
model_move = UndefinedModelMove(model_move=transition.name, objects=None, silent=transition.silent)
set_properties_of_transition(new_transition, TransitionSignature(transition.name, signature_in,
                                                                    signature_in, model_move))
```

**After**

```python
# add signature to transition 
model_move = UndefinedModelMove(model_move=transition.label, objects=None, silent=transition.silent)
set_properties_of_transition(new_transition, TransitionSignature(transition.label, signature_in, 
                                                                    signature_in, model_move))
```

Since, OCPN discovery uses [`new_inductive.py`](https://github.com/ocpm/ocpa/blob/main/ocpa/algo/discovery/ocpn/versions/new_inductive.py) instead of old [`inductive.py`](https://github.com/ocpm/ocpa/blob/main/ocpa/algo/discovery/ocpn/versions/inductive.py), the `name` field of discoverd `ObjectCentricPetriNet` object's `Transition`, is no longer activity label (e.g. `Pick Item`) but uuid (e.g. `9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d`). The activity label is stored on the `label` attribute of `Transition` object.

This prohibits alignment calculation function not comparing activity label properly, which cannot match any synchronous moves.


## Fixed Result

Now the alignment result calculated as expected.

<img width="515" height="411" alt="fixed_alignment" src="https://github.com/user-attachments/assets/0921c89e-5d8a-4abd-96f9-44d7a52861cb" />
